### PR TITLE
chore: adding code space configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,7 @@
   },
   "features": {
     "github-cli": "latest",
-    "azure-cli": "latest",
-    "ghcr.io/devcontainers/features/python:1": {}
+    "azure-cli": "latest"
   },
   "postCreateCommand": ".devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,6 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "msazurermtools.azurerm-vscode-tools",
-        "ms-azuretools.vscode-bicep",
-        "ms-dotnettools.csharp",
-        "ms-azuretools.vscode-docker",
         "editorconfig.editorconfig",
         "github.vscode-pull-request-github",
         "ms-python.python"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Bicep Development Environment",
+  "image": "mcr.microsoft.com/vscode/devcontainers/universal:2",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "msazurermtools.azurerm-vscode-tools",
+        "ms-azuretools.vscode-bicep",
+        "ms-dotnettools.csharp",
+        "ms-azuretools.vscode-docker",
+        "editorconfig.editorconfig",
+        "github.vscode-pull-request-github",
+        "ms-python.python"
+      ],
+      "settings": {
+        "editor.detectIndentation": false,
+        "python.testing.pytestArgs": [
+            "partnercenter/azext_partnercenter/tests"
+        ],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true
+      }
+    }
+  },
+  "features": {
+    "github-cli": "latest",
+    "azure-cli": "latest",
+    "ghcr.io/devcontainers/features/python:1": {}
+  },
+  "postCreateCommand": ".devcontainer/postCreateCommand.sh"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -m pip install --user partnercenter[test]

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-python -m pip install --user partnercenter[test]
+python -m venv env
+source env/bin/activate
+pip install azdev
+
+azdev setup -r .
+azdev extension repo add ../partnercenter-cli-extension/
+azdev extension add partnercenter

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "editor.detectIndentation": false
+    "editor.detectIndentation": false,
+    "python.testing.pytestArgs": [
+        "partnercenter/azext_partnercenter/tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/partnercenter/setup.py
+++ b/partnercenter/setup.py
@@ -47,6 +47,13 @@ DEPENDENCIES = [
     'pydantic'
 ]
 
+EXTRA_DEPENDENCIES = {
+    'test': [
+        'azure-cli-core',
+        'azure-cli-testsdk',
+    ]
+}
+
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()
 with open('HISTORY.rst', 'r', encoding='utf-8') as f:
@@ -64,5 +71,6 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(),
     install_requires=DEPENDENCIES,
+    extra_requires=EXTRA_DEPENDENCIES,
     package_data={'azext_partnercenter': ['azext_metadata.json']},
 )


### PR DESCRIPTION
Add a codespace configuration that makes it easy to open the project and run the unit tests.

Also adding a set of EXTRA_DEPS in setup to easily install additional requirements needed for testing.

Though, still have some work to do to get the tests working, this config loads them into VSCode test browser.

<img width="970" alt="image" src="https://user-images.githubusercontent.com/9027725/221384221-fae63d54-74ae-494a-97a4-21da28ede540.png">

