### PR TITLE
ci: Add Pull Request Template and PR Title Check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Description
+
+<!--Why this PR? What is changed? What is the effect? etc.-->
+
+If you haven't already, read the full [contribution guide](../README.md#contributing). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, edit the PR description and run through the relevant checklist below.

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,0 +1,17 @@
+name: "Semantic PR Check"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #178 

Instead of including the "Type of Change" in the PR template, I have added a github action that will check for the prefix directly in the PR title.

This will be leveraged in the next workflow that I will propose that can be used to automate "updating" the version number and creating the release on github. - (stashed over here for now https://github.com/dciborow/partnercenter-cli-extension/blob/main/.github/workflows/create-release.yml)