### PR TITLE
fix: fixing pinned version

### DIFF
--- a/partnercenter/setup.py
+++ b/partnercenter/setup.py
@@ -40,7 +40,7 @@ DEPENDENCIES = [
     'docker',
     'azure-storage-blob',
     'requests',
-    'pydantic'
+    'pydantic<2'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Adding pydantic version to setup.py 

This PR should close issue #209.  I adds a specific version to the pydantic module to be < 2. 

Closes #209.
